### PR TITLE
Prevent InvalidOperationException on DocumentPathContext

### DIFF
--- a/Source/JsonApiFramework.Server/Hypermedia/Internal/DocumentPathContext.cs
+++ b/Source/JsonApiFramework.Server/Hypermedia/Internal/DocumentPathContext.cs
@@ -54,7 +54,11 @@ namespace JsonApiFramework.Server.Hypermedia.Internal
         #region IDocumentPathContext Implementation
         public Type GetPrimaryClrResourceType()
         {
-            var clrResourceType = this.ClrResourceTypes.Last();
+            var clrResourceType = typeof(Type);
+            if (ClrResourceTypes.Any())
+            {
+                clrResourceType = this.ClrResourceTypes.Last();
+            }
             return clrResourceType;
         }
         #endregion


### PR DESCRIPTION
The method GetPrimaryClrResourceType() throws an InvalidOperationException on the .Last() call because ClrResourceTypes at times can be an empty collection. 

> System.InvalidOperationException
  HResult=0x80131509
  Message=Sequence contains no elements
  Source=System.Linq
  StackTrace:
   at System.Linq.Enumerable.Last[TSource](IEnumerable`1 source)
   at JsonApiFramework.Server.Hypermedia.Internal.DocumentPathContext.GetPrimaryClrResourceType() in F:\repos\JsonApiFramework\Source\JsonApiFramework.Server\Hypermedia\Internal\DocumentPathContext.cs:line 57

Shielding the code by making the code check if ClrResourceTypes has any elements before performing the .Last() call.

