### PR TITLE
Fix #71

### DIFF
--- a/Source/JsonApiFramework.Core/Conventions/INamingConventionsBuilder.cs
+++ b/Source/JsonApiFramework.Core/Conventions/INamingConventionsBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2015–Present Scott McDonald. All rights reserved.
+// Copyright (c) 2015â€“Present Scott McDonald. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.md in the project root for license information.
 namespace JsonApiFramework.Conventions
 {
@@ -7,11 +7,13 @@ namespace JsonApiFramework.Conventions
         // PUBLIC METHODS ///////////////////////////////////////////////////
         #region Methods
         INamingConventionsBuilder AddCamelCaseNamingConvention();
+        INamingConventionsBuilder AddPascalCaseNamingConvention();
         INamingConventionsBuilder AddLowerCaseNamingConvention();
         INamingConventionsBuilder AddPluralNamingConvention();
         INamingConventionsBuilder AddSingularNamingConvention();
         INamingConventionsBuilder AddStandardMemberNamingConvention();
         INamingConventionsBuilder AddUpperCaseNamingConvention();
+        INamingConventionsBuilder AddCustomNamingConvention(INamingConvention convention);
         #endregion
     }
 }

--- a/Source/JsonApiFramework.Core/Conventions/Internal/NamingConventionsBuilder.cs
+++ b/Source/JsonApiFramework.Core/Conventions/Internal/NamingConventionsBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2015–Present Scott McDonald. All rights reserved.
+// Copyright (c) 2015â€“Present Scott McDonald. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.md in the project root for license information.
 
 using System.Collections.Generic;
@@ -18,6 +18,12 @@ namespace JsonApiFramework.Conventions.Internal
         public INamingConventionsBuilder AddCamelCaseNamingConvention()
         {
             this.NamingConventions.Add(new CamelCaseNamingConvention());
+            return this;
+        }
+
+        public INamingConventionsBuilder AddPascalCaseNamingConvention()
+        {
+            this.NamingConventions.Add(new PascalCaseNamingConvention());
             return this;
         }
 
@@ -50,6 +56,13 @@ namespace JsonApiFramework.Conventions.Internal
             this.NamingConventions.Add(new UpperCaseNamingConvention());
             return this;
         }
+
+        public INamingConventionsBuilder AddCustomNamingConvention(INamingConvention convention)
+        {
+            this.NamingConventions.Add(convention);
+            return this;
+        }
+
         #endregion
 
         #region Factory Methods

--- a/Source/JsonApiFramework.Core/Conventions/Internal/PascalCaseNamingConvention.cs
+++ b/Source/JsonApiFramework.Core/Conventions/Internal/PascalCaseNamingConvention.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) 2015–Present Scott McDonald. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.md in the project root for license information.
+
+using Humanizer;
+
+namespace JsonApiFramework.Conventions.Internal
+{
+    /// <summary>Naming convention that applies camelCasing to members.</summary>
+    internal class PascalCaseNamingConvention : INamingConvention
+    {
+        // PUBLIC METHODS ///////////////////////////////////////////////////
+        #region INamingConvention Implementation
+        public string Apply(string oldName)
+        {
+            return string.IsNullOrWhiteSpace(oldName) ? oldName : oldName.Pascalize();
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
Adds PascalCaseNamingConvention and ability to add custom naming convention providers via the builder