### PR TITLE
feat: add ground work for attribute based service model configuration

### DIFF
--- a/JsonApiFramework.sln
+++ b/JsonApiFramework.sln
@@ -33,6 +33,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JsonApiFramework.Server.Tes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JsonApiFramework.Server.Tests", "Tests\JsonApiFramework.Server.Tests\JsonApiFramework.Server.Tests.csproj", "{2C8AAD56-C6CB-4CED-BD86-9FD6FA7DC57C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "JsonApiFramework.Attributes", "Source\JsonApiFramework.Attributes\JsonApiFramework.Attributes.csproj", "{DE48764C-A5DD-4F7B-9039-11C11383A60A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -94,6 +96,10 @@ Global
 		{A7B125EC-CB97-4809-BB38-DFD78FCD0699}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A7B125EC-CB97-4809-BB38-DFD78FCD0699}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A7B125EC-CB97-4809-BB38-DFD78FCD0699}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE48764C-A5DD-4F7B-9039-11C11383A60A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE48764C-A5DD-4F7B-9039-11C11383A60A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE48764C-A5DD-4F7B-9039-11C11383A60A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE48764C-A5DD-4F7B-9039-11C11383A60A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{FB1A1D5E-D12D-48EB-AB88-C3EDC1E8651C} = {C9082D1A-3F74-44F6-801A-2D23F769EF16}
@@ -109,5 +115,6 @@ Global
 		{2C8AAD56-C6CB-4CED-BD86-9FD6FA7DC57C} = {90D57CDD-244E-4F09-9BFE-CC6588BF97BB}
 		{F8E670F8-F896-4A4F-A1F2-53B182F0FAF1} = {C9082D1A-3F74-44F6-801A-2D23F769EF16}
 		{A7B125EC-CB97-4809-BB38-DFD78FCD0699} = {90D57CDD-244E-4F09-9BFE-CC6588BF97BB}
+		{DE48764C-A5DD-4F7B-9039-11C11383A60A} = {C9082D1A-3F74-44F6-801A-2D23F769EF16}
 	EndGlobalSection
 EndGlobal

--- a/Source/JsonApiFramework.Attributes/Attributes/JsonApiAttributeAttribute.cs
+++ b/Source/JsonApiFramework.Attributes/Attributes/JsonApiAttributeAttribute.cs
@@ -1,0 +1,27 @@
+﻿namespace JsonApiFramework.Attributes.Attributes;
+
+[AttributeUsage(AttributeTargets.Property)]
+public class JsonApiAttributeAttribute : Attribute
+{
+    /// <summary>
+    /// Mark a property with the JSON:API attribute name, using convention based naming
+    /// </summary>
+    public JsonApiAttributeAttribute()
+    {
+    }
+
+    /// <summary>
+    /// Mark a property with the JSON:API attribute name, using a custom name
+    /// </summary>
+    /// <param name="attributeName"></param>
+    public JsonApiAttributeAttribute(string attributeName)
+    {
+        AttributeName = attributeName;
+    }
+
+    public string? AttributeName { get; }
+
+    public bool Ignore { get; init; }
+
+    public bool Hide { get; init; }
+}

--- a/Source/JsonApiFramework.Attributes/Attributes/JsonApiComplexTypeAttribute.cs
+++ b/Source/JsonApiFramework.Attributes/Attributes/JsonApiComplexTypeAttribute.cs
@@ -1,0 +1,12 @@
+﻿namespace JsonApiFramework.Attributes.Attributes;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class JsonApiComplexTypeAttribute : Attribute
+{
+    /// <summary>
+    /// Mark an entity class as JSON:API complex type
+    /// </summary>
+    public JsonApiComplexTypeAttribute()
+    {
+    }
+}

--- a/Source/JsonApiFramework.Attributes/Attributes/JsonApiHomeResourceAttribute.cs
+++ b/Source/JsonApiFramework.Attributes/Attributes/JsonApiHomeResourceAttribute.cs
@@ -1,0 +1,6 @@
+﻿namespace JsonApiFramework.Attributes.Attributes;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class JsonApiHomeResourceAttribute : Attribute
+{
+}

--- a/Source/JsonApiFramework.Attributes/Attributes/JsonApiResourceIdentityAttribute.cs
+++ b/Source/JsonApiFramework.Attributes/Attributes/JsonApiResourceIdentityAttribute.cs
@@ -1,0 +1,6 @@
+﻿namespace JsonApiFramework.Attributes.Attributes;
+
+[AttributeUsage(AttributeTargets.Property)]
+public class JsonApiResourceIdentityAttribute : Attribute
+{
+}

--- a/Source/JsonApiFramework.Attributes/Attributes/JsonApiResourceTypeAttribute.cs
+++ b/Source/JsonApiFramework.Attributes/Attributes/JsonApiResourceTypeAttribute.cs
@@ -1,0 +1,23 @@
+﻿namespace JsonApiFramework.Attributes.Attributes;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class JsonApiResourceTypeAttribute : Attribute
+{
+    /// <summary>
+    /// Mark an entity class as JSON:API resource type, using convention based naming
+    /// </summary>
+    public JsonApiResourceTypeAttribute()
+    {
+    }
+
+    /// <summary>
+    /// Mark an entity class as JSON:API resource type, using a custom name
+    /// </summary>
+    /// <param name="resourceType"></param>
+    public JsonApiResourceTypeAttribute(string resourceType)
+    {
+        ResourceType = resourceType;
+    }
+
+    public string? ResourceType { get; }
+}

--- a/Source/JsonApiFramework.Attributes/Extensions/ComplexTypeBuilderExtensions.cs
+++ b/Source/JsonApiFramework.Attributes/Extensions/ComplexTypeBuilderExtensions.cs
@@ -1,0 +1,50 @@
+﻿using System.Reflection;
+using JsonApiFramework.Attributes.Attributes;
+using JsonApiFramework.ServiceModel.Configuration;
+
+namespace JsonApiFramework.Attributes.Extensions;
+
+public static class ComplexTypeBuilderExtensions
+{
+    public static IComplexTypeBuilder<TResource> ApplyJsonApiAttributes<TResource>(this IComplexTypeBuilder<TResource> builder)
+        where TResource : class
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        var properties = typeof(TResource).GetProperties();
+
+        foreach (var property in properties)
+        {
+            ApplyAttributes(builder, property);
+        }
+
+        return builder;
+    }
+
+    private static void ApplyAttributes<TResource>(IComplexTypeBuilder<TResource> builder, PropertyInfo property)
+        where TResource : class
+    {
+        var jsonApiAttribute = property.GetCustomAttribute<JsonApiAttributeAttribute>();
+        if (jsonApiAttribute is null)
+        {
+            return;
+        }
+
+        var attributeBuilder = builder.Attribute(property.Name, property.PropertyType);
+        if (!string.IsNullOrEmpty(jsonApiAttribute.AttributeName))
+        {
+            attributeBuilder.SetApiPropertyName(jsonApiAttribute.AttributeName);
+        }
+
+        if (jsonApiAttribute.Ignore)
+        {
+            attributeBuilder.Ignore();
+        }
+
+        if (jsonApiAttribute.Hide)
+        {
+            attributeBuilder.Hide();
+        }
+    }
+
+}

--- a/Source/JsonApiFramework.Attributes/Extensions/ResourceTypeBuilderExtensions.cs
+++ b/Source/JsonApiFramework.Attributes/Extensions/ResourceTypeBuilderExtensions.cs
@@ -1,0 +1,85 @@
+﻿using System.Reflection;
+using JsonApiFramework.Attributes.Attributes;
+using JsonApiFramework.ServiceModel.Configuration;
+
+namespace JsonApiFramework.Attributes.Extensions;
+
+public static class ResourceTypeBuilderExtensions
+{
+    public static IResourceTypeBuilder<TResource> ApplyJsonApiAttributes<TResource>(this IResourceTypeBuilder<TResource> builder)
+        where TResource : class
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        ApplyHomeResourceAttribute(builder);
+
+        var properties = typeof(TResource).GetProperties();
+
+        foreach (var property in properties)
+        {
+            ApplyResourceIdentity(builder, property);
+            ApplyAttributes(builder, property);
+        }
+
+        return builder;
+    }
+
+    private static void ApplyHomeResourceAttribute<TResource>(IResourceTypeBuilder<TResource> builder)
+        where TResource : class
+    {
+        var jsonApiAttribute = typeof(TResource).GetCustomAttribute<JsonApiHomeResourceAttribute>();
+        if (jsonApiAttribute is null)
+        {
+            return;
+        }
+
+        // Explicitly set the JSON API type as "api-entry-point".
+        // Configure ApiEntryPoint resource as a "singleton" by not specifying any identifier property.
+        builder.ResourceIdentity()
+            .SetApiType("api-entry-point");
+    }
+
+    private static void ApplyResourceIdentity<TResource>(IResourceTypeBuilder<TResource> builder, PropertyInfo property)
+        where TResource : class
+    {
+        var jsonApiAttribute = property.GetCustomAttribute<JsonApiResourceIdentityAttribute>();
+        if (jsonApiAttribute is null)
+        {
+            return;
+        }
+
+        var identityBuilder = builder.ResourceIdentity(property.Name, property.PropertyType);
+
+        var jsonResourceAttribute = property.DeclaringType!.GetCustomAttribute<JsonApiResourceTypeAttribute>();
+        if (jsonResourceAttribute?.ResourceType is not null)
+        {
+            identityBuilder.SetApiType(jsonResourceAttribute.ResourceType);
+        }
+    }
+
+    private static void ApplyAttributes<TResource>(IResourceTypeBuilder<TResource> builder, PropertyInfo property)
+        where TResource : class
+    {
+        var jsonApiAttribute = property.GetCustomAttribute<JsonApiAttributeAttribute>();
+        if (jsonApiAttribute is null)
+        {
+            return;
+        }
+
+        var attributeBuilder = builder.Attribute(property.Name, property.PropertyType);
+        if (!string.IsNullOrEmpty(jsonApiAttribute.AttributeName))
+        {
+            attributeBuilder.SetApiPropertyName(jsonApiAttribute.AttributeName);
+        }
+
+        if (jsonApiAttribute.Ignore)
+        {
+            attributeBuilder.Ignore();
+        }
+
+        if (jsonApiAttribute.Hide)
+        {
+            attributeBuilder.Hide();
+        }
+    }
+}

--- a/Source/JsonApiFramework.Attributes/Extensions/ServiceModelBuilderExtensions.cs
+++ b/Source/JsonApiFramework.Attributes/Extensions/ServiceModelBuilderExtensions.cs
@@ -1,0 +1,148 @@
+﻿using System.Reflection;
+using JsonApiFramework.Attributes.Attributes;
+using JsonApiFramework.ServiceModel.Configuration;
+
+namespace JsonApiFramework.Attributes.Extensions;
+
+public static class ServiceModelBuilderExtensions
+{
+    /// <summary>
+    /// Discover and add all <see cref="IResourceTypeBuilder"/> and <see cref="IComplexTypeBuilder"/> implementations from the calling assembly.
+    /// Also registers resources annotated with the <see cref="JsonApiResourceTypeAttribute"/> or <see cref="JsonApiComplexTypeAttribute"/> from the calling assembly.
+    /// Also define home resource, when a class is annotated with the <see cref="JsonApiHomeResourceAttribute"/>.
+    /// </summary>
+    /// <remarks>
+    /// Relies heavily on reflection to discover and add the configurations. Use with caution, consider caching the service model.
+    /// In the future, this could be improved by using source generation.
+    /// </remarks>
+    /// <param name="builder"></param>
+    /// <returns></returns>
+    public static ServiceModelBuilder AddJsonApiConfigurations(this ServiceModelBuilder builder)
+    {
+        return AddJsonApiConfigurations(builder, Assembly.GetCallingAssembly());
+    }
+
+    /// <summary>
+    /// Discover and add all <see cref="IResourceTypeBuilder"/> and <see cref="IComplexTypeBuilder"/> implementations from the specified assembly.
+    /// Also registers resources annotated with the <see cref="JsonApiResourceTypeAttribute"/> or <see cref="JsonApiComplexTypeAttribute"/> from the specified assembly.
+    /// Also define home resource, when a class is annotated with the <see cref="JsonApiHomeResourceAttribute"/>.
+    /// </summary>
+    /// <remarks>
+    /// Relies heavily on reflection to discover and add the configurations. Use with caution, consider caching the service model.
+    /// In the future, this could be improved by using source generation.
+    /// </remarks>
+    /// <param name="builder"></param>
+    /// <returns></returns>
+    public static ServiceModelBuilder AddJsonApiConfigurations<T>(this ServiceModelBuilder builder)
+    {
+        return AddJsonApiConfigurations(builder, typeof(T).Assembly);
+    }
+    
+    /// <summary>
+    /// Discover and add all <see cref="IResourceTypeBuilder"/> and <see cref="IComplexTypeBuilder"/> implementations from the specified assemblies.
+    /// Also registers resources annotated with the <see cref="JsonApiResourceTypeAttribute"/> or <see cref="JsonApiComplexTypeAttribute"/> from the specified assemblies.
+    /// Also define home resource, when a class is annotated with the <see cref="JsonApiHomeResourceAttribute"/>.
+    /// </summary>
+    /// <remarks>
+    /// Relies heavily on reflection to discover and add the configurations. Use with caution, consider caching the service model.
+    /// In the future, this could be improved by using source generation.
+    /// </remarks>
+    /// <param name="builder"></param>
+    /// <param name="assemblies"></param>
+    /// <returns></returns>
+    public static ServiceModelBuilder AddJsonApiConfigurations(this ServiceModelBuilder builder, params Assembly[] assemblies)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(assemblies);
+
+        AddResourceTypeClassConfigurations(builder, assemblies);
+        // TODO add complex type class configurations
+
+        AddResourceTypeAttributes(builder, assemblies);
+        AddComplexTypeAttributes(builder, assemblies);
+
+        AddHomeResource(builder, assemblies);
+
+        return builder;
+    }
+
+    private static void AddResourceTypeAttributes(ServiceModelBuilder builder, params Assembly[] assemblies)
+    {
+        var types = assemblies.SelectMany(assembly => assembly.GetTypes())
+            .Where(t => t.GetCustomAttributes<JsonApiResourceTypeAttribute>().Any());
+
+        foreach (var type in types)
+        {
+            ApplyResourceTypeJsonApiAttributes(builder, type);
+        }
+    }
+
+    private static void ApplyResourceTypeJsonApiAttributes(ServiceModelBuilder builder, Type type)
+    {
+        // We have to use reflection to call the generic method, since there is no non-generic method variant :(
+        var resourceMethod = typeof(ServiceModelBuilder).GetMethod(nameof(ServiceModelBuilder.Resource));
+        var genericResourceMethod = resourceMethod!.MakeGenericMethod(type);
+        var resourceTypeBuilder = genericResourceMethod.Invoke(builder, null);
+
+        var applyJsonApiAttributesMethod = typeof(ResourceTypeBuilderExtensions).GetMethod(nameof(ResourceTypeBuilderExtensions.ApplyJsonApiAttributes));
+        var genericApplyJsonApiAttributesMethod = applyJsonApiAttributesMethod!.MakeGenericMethod(type);
+        genericApplyJsonApiAttributesMethod.Invoke(null, [resourceTypeBuilder]);
+    }
+
+    private static void AddComplexTypeAttributes(ServiceModelBuilder builder, params Assembly[] assemblies)
+    {
+        var types = assemblies.SelectMany(assembly => assembly.GetTypes())
+            .Where(t => t.GetCustomAttributes<JsonApiComplexTypeAttribute>().Any());
+
+        foreach (var type in types)
+        {
+            ApplyComplexTypeJsonApiAttributes(builder, type);
+        }
+    }
+
+    private static void ApplyComplexTypeJsonApiAttributes(ServiceModelBuilder builder, Type type)
+    {
+        // We have to use reflection to call the generic method, since there is no non-generic method variant :(
+        var complexMethod = typeof(ServiceModelBuilder).GetMethod(nameof(ServiceModelBuilder.Complex));
+        var genericComplexMethod = complexMethod!.MakeGenericMethod(type);
+        var complexTypeBuilder = genericComplexMethod.Invoke(builder, null);
+
+        var applyJsonApiAttributesMethod = typeof(ComplexTypeBuilderExtensions).GetMethod(nameof(ComplexTypeBuilderExtensions.ApplyJsonApiAttributes));
+        var genericApplyJsonApiAttributesMethod = applyJsonApiAttributesMethod!.MakeGenericMethod(type);
+        genericApplyJsonApiAttributesMethod.Invoke(null, [complexTypeBuilder]);
+    }
+
+    private static void AddHomeResource(ServiceModelBuilder builder, params Assembly[] assemblies)
+    {
+        var type = assemblies.SelectMany(assembly => assembly.GetTypes())
+            .FirstOrDefault(t => t.GetCustomAttributes<JsonApiHomeResourceAttribute>().Any());
+
+        if (type is null)
+        {
+            // This means you have to manually configure the home resource in the configuration factory
+            return;
+        }
+
+        // We have to use reflection to call the generic method, since there is no non-generic method variant :(
+        var method = typeof(ServiceModelBuilder).GetMethod(nameof(builder.HomeResource));
+        var genericMethod = method!.MakeGenericMethod(type);
+        genericMethod.Invoke(builder, null);
+
+        // Since the home resource is not annotated as resource type, we should apply the JSON API attributes explicitly
+        ApplyResourceTypeJsonApiAttributes(builder, type);
+    }
+
+    private static void AddResourceTypeClassConfigurations(ServiceModelBuilder builder, params Assembly[] assemblies)
+    {
+        var resourceTypeBuilderType = typeof(ResourceTypeBuilder<>);
+
+        var types = assemblies.SelectMany(assembly => assembly.GetTypes())
+            .Where(t => t.BaseType is {IsGenericType: true} && t.BaseType.GetGenericTypeDefinition() == resourceTypeBuilderType);
+
+        foreach (var type in types)
+        {
+            var instance = Activator.CreateInstance(type);
+            builder.Configurations.Add((IResourceTypeBuilder)instance!);
+        }
+    }
+}

--- a/Source/JsonApiFramework.Attributes/JsonApiFramework.Attributes.csproj
+++ b/Source/JsonApiFramework.Attributes/JsonApiFramework.Attributes.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <PackageId>JsonApiFramework.Attributes</PackageId>
+        <Version>2.12.0</Version>
+        <Authors>Scott McDonald</Authors>
+        <Company>Scott McDonald</Company>
+        <Product>JsonApiFramework [Attributes]</Product>
+        <Description>Allows (partial) attribute based configuration in JsonApiFramework.</Description>
+        <Copyright>Copyright © 2015–2020 Scott McDonald</Copyright>
+        <PackageLicenseUrl>https://raw.githubusercontent.com/scott-mcdonald/JsonApiFramework/master/LICENSE.md</PackageLicenseUrl>
+        <PackageProjectUrl>https://github.com/scott-mcdonald/JsonApiFramework</PackageProjectUrl>
+        <PackageIconUrl>https://raw.githubusercontent.com/scott-mcdonald/JsonApiFramework/master/LogoIcon.png</PackageIconUrl>
+        <PackageTags>.net portable jsonapi framework client</PackageTags>
+        <AssemblyVersion>2.12.0.0</AssemblyVersion>
+        <FileVersion>2.12.0.33</FileVersion>
+        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\JsonApiFramework.Infrastructure\JsonApiFramework.Infrastructure.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Certainly this PR is work in progress, as there are still things to do, like:

- add documentation
- add unit tests
- complex type configuration discovery
- add relationships configuration by attributes

I am already sharing this PR to see if anyone's interested in these features. My goal was to completely eliminate the need to configure the service model using the configuration (ResrouceTypeBuilder and ComplexTypeBuilder) classes, and to be able to configure it using annotations.

I am currently using this in one of my own projects, in which I'm exploring JsonApiFramework for the first time.